### PR TITLE
Downmix with DEE

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ optional arguments:
                         DDP5.1: 1024
                         DDP7.1: 1536
   -c CHANNELS, --channels CHANNELS
+                        number of channels in the input file (automatically downmixes to 5.1 when outputting DD).
                         default: 6
   -d DIALNORM, --dialnorm DIALNORM
                         default: -31

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ optional arguments:
                         DDP5.1: 1024
                         DDP7.1: 1536
   -c CHANNELS, --channels CHANNELS
-                        number of channels in the input file (automatically downmixes to 5.1 when outputting DD).
+                        number of channels in the input file (automatically downmixes to 5.1 when encoding DD from 7.1 source).
                         default: 6
   -d DIALNORM, --dialnorm DIALNORM
                         default: -31

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ optional arguments:
                         DDP5.1: 1024
                         DDP7.1: 1536
   -c CHANNELS, --channels CHANNELS
-                        number of channels in the input file (automatically downmixes to 5.1 when encoding DD from 7.1 source).
+                        number of channels in the input file (automatically downmixes to 5.1 when encoding DD from 7.1 input).
                         default: 6
   -d DIALNORM, --dialnorm DIALNORM
                         default: -31

--- a/deew.py
+++ b/deew.py
@@ -134,9 +134,9 @@ def encode(settings):
         dee_out_path = f'{wpc(config["temp_path"])}\{basename(fl, "xml")}'
     else:
         dee_out_path = f'{config["temp_path"]}/{basename(fl, "xml")}'
-    ffmpeg_args = [config['ffmpeg_path'], '-y', '-i', fl, *(['-ss', '0.00533'] if compensate else []), '-ac', args.channels, '-c:a', 'pcm_s24le', '-rf64', 'always', os.path.join(config['temp_path'], basename(fl, 'wav'))]
+    ffmpeg_args = [config['ffmpeg_path'], '-y', '-i', fl, *(['-ss', '0.00533'] if compensate else []), '-c:a', 'pcm_s24le', '-rf64', 'always', os.path.join(config['temp_path'], basename(fl, 'wav'))]
     dee_args = [config['dee_path'], '-x', dee_out_path]
-    ffmpeg_args_print = [f'[bold blue]{config["ffmpeg_path"]}[/bold blue]', '-y', '-i', f'[bold green]{fl}[/bold green]', *(['-ss', '[bold color(231)]0.00533[/bold color(231)]'] if compensate else []), '-ac', args.channels, '[not bold white]-c:a[/not bold white]', '[bold color(231)]pcm_s24le[/bold color(231)]', '-rf64', '[bold color(231)]always[/bold color(231)]', f'[bold magenta]{os.path.join(config["temp_path"], basename(fl, "wav"))}[/bold magenta]']
+    ffmpeg_args_print = [f'[bold blue]{config["ffmpeg_path"]}[/bold blue]', '-y', '-i', f'[bold green]{fl}[/bold green]', *(['-ss', '[bold color(231)]0.00533[/bold color(231)]'] if compensate else []), '[not bold white]-c:a[/not bold white]', '[bold color(231)]pcm_s24le[/bold color(231)]', '-rf64', '[bold color(231)]always[/bold color(231)]', f'[bold magenta]{os.path.join(config["temp_path"], basename(fl, "wav"))}[/bold magenta]']
     dee_args_print = [f'[bold blue]{config["dee_path"]}[/bold blue]', '-x', f'[bold magenta]{dee_out_path}[/bold magenta]']
 
     if not args.progress:
@@ -185,10 +185,12 @@ def main():
                 xmlbase['job_config']['filter']['audio']['pcm_to_ddp']['encoder_mode'] = 'ddp'
         if args.format.lower() == 'dd':
             pformat = '[bold green]DD[/bold green]'
-            if args.channels == '8' or args.bitrate > 640:
-                printexit('[red]ERROR: channels for dd format has to be 6 and bitrate has to be 640 or lower.[/red]')
+            if args.bitrate > 640:
+                printexit('[red]ERROR: cbitrate for dd format has to be 640 or lower.[/red]')
             elif args.bitrate == 0:
                 args.bitrate = '640'
+            if args.channels == '8':
+                xmlbase['job_config']['filter']['audio']['pcm_to_ddp']['downmix_config'] = '5.1'
             xmlbase['job_config']['filter']['audio']['pcm_to_ddp']['encoder_mode'] = 'dd'
         xmlbase['job_config']['filter']['audio']['pcm_to_ddp']['data_rate'] = args.bitrate
     elif args.format.lower() == 'thd':

--- a/deew.py
+++ b/deew.py
@@ -45,7 +45,7 @@ parser.add_argument('-b', '--bitrate',
                     help='default:\nDD5.1: 640\nDDP5.1: 1024\nDDP7.1: 1536')
 parser.add_argument('-c', '--channels',
                     default='6',
-                    help='default: 6')
+                    help='number of channels in the input file (automatically downmixes to 5.1 when encoding DD from 7.1 input).\ndefault: 6')
 parser.add_argument('-d', '--dialnorm',
                     type=int,
                     default=-31,
@@ -201,7 +201,12 @@ def main():
     xmlbase['job_config']['input']['audio']['wav']['storage']['local']['path'] = f'\"{wpc(config["temp_path"])}\"'
     xmlbase['job_config']['misc']['temp_dir']['path'] = f'\"{wpc(config["temp_path"])}\"'
 
-    pchannels = '[bold cyan]5.1[/bold cyan]' if args.channels == '6' else '[bold cyan]7.1[/bold cyan]'
+    if args.channels == '6':
+        pchannels = '[bold cyan]5.1[/bold cyan]'
+    elif args.channels == '8' and args.format.lower() == 'dd':
+        pchannels = '[bold cyan]5.1(downmixed from 7.1)[/bold cyan]'
+    else:
+        pchannels = '[bold cyan]7.1[/bold cyan]'
     pbitrate = f'[yellow]{args.bitrate} kbps[/yellow]'
     print(f'encoding {pformat}', end='', flush=True)
     if args.format.lower() != 'thd':


### PR DESCRIPTION
Downmixing with DEE instead of ffmpeg, which requires the user to provide the number of channels in the input file and prevents encoding 5.1 input to 7.1 TrueHD (unfortunately cannot prevent encoding 5.1 input to 7.1 DDP).