### PR TITLE
Small XML change

### DIFF
--- a/xml/ddp.xml
+++ b/xml/ddp.xml
@@ -37,7 +37,7 @@
         <append_silence_duration>0.0</append_silence_duration>    <!-- string -->
         <lfe_on>true</lfe_on>    <!-- boolean: true or false -->
         <dolby_surround_mode>not_indicated</dolby_surround_mode>    <!-- One of: yes, no, not_indicated -->
-        <dolby_surround_ex_mode>not_indicated</dolby_surround_ex_mode>    <!-- One of: yes, no, not_indicated -->
+        <dolby_surround_ex_mode>no</dolby_surround_ex_mode>    <!-- One of: yes, no, not_indicated -->
         <user_data>-1</user_data>    <!-- integer: from -1 to 65535 -->
         <drc>
           <line_mode_drc_profile>film_light</line_mode_drc_profile>    <!-- One of: film_standard, film_light, music_standard, music_light, speech -->


### PR DESCRIPTION
Changed to match DEE default. This option is only used in 5.1 mode as Blu-ray mode automatically changes it to `yes`. See: `WARNING: pcm_to_ddp: Auto-enabling dolby_surround_ex_mode=yes in Blu-ray mode.`